### PR TITLE
fix(docs): update instructions on install projects

### DIFF
--- a/serverless-functions-in-depth-part-1/README.md
+++ b/serverless-functions-in-depth-part-1/README.md
@@ -13,10 +13,10 @@ To run this app:
 1. Clone the repository
 
 ```sh
-git clone https://github.com/dabit3/serverless-functions-in-depth-part-1.git
+git clone https://github.com/dabit3/full-stack-serverless-code.git
 ```
 
-2. Change into the directory
+1. Change into the directory
 
 ```sh
 cd serverless-functions-in-depth-part-1

--- a/serverless-functions-in-depth-part-2/README.md
+++ b/serverless-functions-in-depth-part-2/README.md
@@ -9,10 +9,10 @@ To run this app:
 1. Clone the repository
 
 ```sh
-git clone https://github.com/dabit3/serverless-functions-in-depth-part-2.git
+git clone https://github.com/dabit3/full-stack-serverless-code.git
 ```
 
-2. Change into the directory
+1. Change into the directory
 
 ```sh
 cd serverless-functions-in-depth-part-2


### PR DESCRIPTION
Instructions on how to run the app for both `serverless-functions-in-depth-part-1` & `serverless-functions-in-depth-part-2` had the wrong repository in the first step.