### PR TITLE
Get user profile data using Auth.currentAuthenticatedUser

### DIFF
--- a/basic-authentication/src/Profile.js
+++ b/basic-authentication/src/Profile.js
@@ -11,7 +11,7 @@ function Profile() {
   const [user, setUser] = useState({}) 
   async function checkUser() {
     try {
-      const data = await Auth.currentUserPoolUser()
+      const data = await Auth.currentAuthenticatedUser()
       const userInfo = { username: data.username, ...data.attributes, }
       setUser(userInfo)
     } catch (err) { console.log('error: ', err) }

--- a/custom-authentication/src/Profile.js
+++ b/custom-authentication/src/Profile.js
@@ -17,7 +17,7 @@ function Profile() {
   const [user, setUser] = useState(null) 
   async function checkUser() {
     try {
-      const data = await Auth.currentUserPoolUser()
+      const data = await Auth.currentAuthenticatedUser()
       const userInfo = { username: data.username, ...data.attributes }
       setUser(userInfo)
     } catch (err) { console.log('error: ', err) }


### PR DESCRIPTION
In the book, it is said that:

> To display the user profile data, we use the `Auth.currentAuthenticatedUser` method. […]

Yet `Auth.currentUserPoolUser` is used in the code sample.

The docs describe both [`currentUserPoolUser`] and [`currentAuthenticatedUser`] very similarly, yet referencing one and then using the other one doesn't help reduce the blurriness between the two main Cognito pieces: _user pools_ and _identity pools_.

The [support knowledge article] trying to clarify this distinction also mentions that 

> _User pools_ are for _authentication_ (identify verification). […]

and at the same time one method has _user pool_ in its name while the other has _authenticated_. So I didn't find much help in clarifying the distinction here either.

<details>
  <summary>Snippet from the book</summary>
  
![4__Introduction_to_Authentication_-_Full_Stack_Serverless](https://user-images.githubusercontent.com/511893/118336355-7d6e0100-b4df-11eb-90a1-de9b1e0b1f1b.png)

</details>

@dabit3 if this PR is going in the opposite direction than intended, please shed some light here. 🙏🏼 


  [`currentAuthenticatedUser`]: https://aws-amplify.github.io/amplify-js/api/classes/authclass.html#currentauthenticateduser
  [`currentUserPoolUser`]: https://aws-amplify.github.io/amplify-js/api/classes/authclass.html#currentuserpooluser
  [support knowledge article]: https://aws.amazon.com/premiumsupport/knowledge-center/cognito-user-pools-identity-pools/
